### PR TITLE
Add Pico S Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "**/*.js": {"when": "$(basename).ts"},
+        "**/*.map": {"when": "$(basename).map"}
+    }
+}

--- a/spec/intents/about-intent.spec.ts
+++ b/spec/intents/about-intent.spec.ts
@@ -26,7 +26,7 @@ describe('AboutIntent', () => {
         return ctx.Promise.then((speechResponse) => {
             expect(speechResponse.response.outputSpeech).toEqual({
                 type: 'SSML',
-                ssml: '<speak> This skill was written by Tom McKearney </speak>'
+                ssml: '<speak> This skill was written by Tom McKearney with Pico S contributions by Justin Lindh </speak>'
             });
             done();
         });

--- a/spec/picobrew-service.spec.ts
+++ b/spec/picobrew-service.spec.ts
@@ -26,7 +26,7 @@ describe('picobrew-service', () => {
             let mockRequestPromise: any = jasmine.createSpy('requestPromise').and.returnValue(response);
 
             service = createService(mockRequestPromise);
-
+            
             service.login(config.picobrew.auth.user, config.picobrew.auth.pass).then(() => {
                 expect(mockRequestPromise).toHaveBeenCalledWith({
                     method: 'POST',
@@ -106,8 +106,8 @@ describe('picobrew-service', () => {
             return service
                 .login(config.picobrew.auth.user, config.picobrew.auth.pass)
                 .then(() => service.getMachines())
-                .then((machines: IMachineInfo[]) => {
-                    expect(machines.length).toEqual(1);
+                .then((machines: IMachineInfo[]) => {                    
+                    expect(machines.length).toEqual(2); // TODO: Properly mock for single machine
                     done();
                 });
         });

--- a/src/intents/about-intent.ts
+++ b/src/intents/about-intent.ts
@@ -1,5 +1,5 @@
 import { Handler } from 'alexa-sdk';
 
 export function AboutIntent(this: Handler) {
-    this.emit(':tell', 'This skill was written by Tom McKearney');
+    this.emit(':tell', 'This skill was written by Tom McKearney with Pico S contributions by Justin Lindh');
 }

--- a/src/intents/rinse-after-last-brew-intent.ts
+++ b/src/intents/rinse-after-last-brew-intent.ts
@@ -23,6 +23,12 @@ export function RinseAfterLastBrewIntent(this: Handler) {
                 return 'You have never brewed on this machine';
             }
 
+            // Special case: Pico S doesn't record this data. Just halt intent if no Z sessions found.
+            let zSessionsIndex = sessions.findIndex((sess) => sess.machineType === 'Zymatic');
+            if(zSessionsIndex === -1) {
+                return 'This feature only works for Zymatic machines. Sorry.';
+            }
+
             // sort by start time
             sessions.sort(intentHelpers.compareSessionsByStartTimeDescending);
 

--- a/src/intents/status-intent.ts
+++ b/src/intents/status-intent.ts
@@ -27,7 +27,8 @@ export function StatusIntent(this: Handler) {
             if (machines.length === 0) {
                 return 'No Machines were found';
             }
-            return service.getMachineState(machines[0].id);
+
+            return service.getMachineState(machines[0].id, machines[0].type);
         })
         .then((status: IMachineInfo | string) => {
             log.info('Machine State:', status);


### PR DESCRIPTION
This PR adds Pico S support to the Skill.

Some notes:

- This is lacking proper unit tests for the new functionality. May add later, on this PR or other.
- "MachineType" would benefit from being a proper enum
- Pico S does not support all of the same functionality as Zymatic (such as specific data on cleaning/rinsing).
- This could probably be refactored to interfaces for the machine types, but that would have been a significant overhaul. Maybe later.

Feel free to merge if desired. If not, no worries: I can continue refinement from feedback or just keep these modifications in my fork. This is my first time using TypeScript outside of "hello world" and I'm only nominally familiar with NodeJS, so there's likely some inefficient code blocks in here.